### PR TITLE
Read from `README.md` instead of `version.md` to conform with current syftbox endpoint standard

### DIFF
--- a/dashboard/syftbox-sdk.js
+++ b/dashboard/syftbox-sdk.js
@@ -9,7 +9,7 @@
     return (
       githubUrl
         .replace("github.com", "raw.githubusercontent.com")
-        .replace(/\/$/, "") + "/main/version.md"
+        .replace(/\/$/, "") + "/main/README.md"
     );
   }
 
@@ -22,7 +22,7 @@
         const masterUrl = rawUrl.replace("/main/", "/master/");
         const masterResponse = await fetch(masterUrl);
         if (!masterResponse.ok) {
-          throw new Error("Failed to fetch version.md from GitHub");
+          throw new Error("Failed to fetch README.md from GitHub");
         }
         return parseFrontmatter(await masterResponse.text());
       }


### PR DESCRIPTION
In `app_route.py` we have the endpoint `@router.get("/status/{app_name}")` which calls `get_all_apps` -> `parse_frontmatter` to look for the version of the app to determine the color of the install button. Let's switch back to use `README.md` in our FL apps to confirm to this standard